### PR TITLE
refactor front end to isolate launchmon dependencies

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,11 +12,11 @@ SWIGFLAGS += -DSTAT_GDB_BE
 endif
 AM_LDFLAGS = $(CODE_COVERAGE_LIBS)
 
-include_HEADERS = STAT.h STAT_FrontEnd.h STAT_BackEnd.h STAT_timer.h STAT_GraphRoutines.h STAT_IncMRNet.h MRNetSymbolReader.h STAT_CircularLogs.h
+include_HEADERS = STAT.h STAT_FrontEnd.h STAT_lmonFrontEnd.h STAT_BackEnd.h STAT_timer.h STAT_GraphRoutines.h STAT_IncMRNet.h MRNetSymbolReader.h STAT_CircularLogs.h
 
 if ENABLE_STATBENCH
 stat_bin_programs_statbench = STATBenchbin STATBenchD
-STATBenchbin_SOURCES = STATBench.C STAT.h STAT_FrontEnd.h STAT_GraphRoutines.h
+STATBenchbin_SOURCES = STATBench.C STAT.h STAT_FrontEnd.h STAT_lmonFrontEnd.h STAT_GraphRoutines.h
 STATBenchD_SOURCES = STATBenchD.C STAT.h STAT_BackEnd.h STAT_GraphRoutines.h
 STATBenchbin_LDADD = libstatfe.la @FELIBS@
 STATBenchD_LDADD = libstatbe.la @BELIBS@
@@ -40,13 +40,13 @@ libcallpathwrap_la_CPPFLAGS = -I@ADEPTUTILSPREFIX@/include -I@CALLPATHPREFIX@/in
 libcallpathwrap_la_LDFLAGS = -L@CALLPATHPREFIX@/lib -Wl,-rpath=@CALLPATHPREFIX@/lib -lcallpath -Wl,-init=depositlightcorewrap_init -ldl
 endif
 
-STATbin_SOURCES = STAT.C STAT.h STAT_FrontEnd.h STAT_GraphRoutines.h
+STATbin_SOURCES = STAT.C STAT.h STAT_FrontEnd.h STAT_lmonFrontEnd.h STAT_GraphRoutines.h
 STATD_SOURCES = STATD.C STAT.h STAT_BackEnd.h STAT_GraphRoutines.h
 STATbin_LDADD = libstatfe.la @FELIBS@
 STATD_LDADD = libstatbe.la @BELIBS@
 
 stat_be_la_sources_base = STAT_BackEnd.C STAT_BackEnd.h STAT.h STAT_timer.h STAT_timer.C STAT_CircularLogs.C
-stat_fe_la_sources_base = STAT_FrontEnd.C STAT_FrontEnd.h STAT.h STAT_timer.h STAT_timer.C
+stat_fe_la_sources_base = STAT_FrontEnd.C STAT_lmonFrontEnd.C STAT_FrontEnd.h STAT_lmonFrontEnd.h STAT.h STAT_timer.h STAT_timer.C
 
 libstatbe_la_SOURCES = $(stat_be_la_sources_base) $(stat_graphlib_sources) $(stat_be_la_sources_fgfs)
 libstatfe_la_SOURCES = $(stat_fe_la_sources_base) $(stat_graphlib_sources) 

--- a/src/STAT.C
+++ b/src/STAT.C
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
     string invocationString;
     StatArgs_t *statArgs;
 
-    statFrontEnd = new STAT_FrontEnd();
+    statFrontEnd = STAT_FrontEnd::make();
 
 
     /* Parse arguments and fill in class variables */

--- a/src/STAT.i
+++ b/src/STAT.i
@@ -191,10 +191,10 @@ namespace DysectAPI {
 }
 #endif
 
+
 class STAT_FrontEnd
 {
     public:
-        STAT_FrontEnd();
         ~STAT_FrontEnd();
 
         StatError_t attachAndSpawnDaemons(unsigned int pid, char *remoteNode = NULL);
@@ -260,6 +260,11 @@ class STAT_FrontEnd
         StatError_t dysectStop();
 #endif
 };
+
+%extend STAT_FrontEnd {
+    STAT_FrontEnd() { return STAT_FrontEnd::make(); }
+};
+
 
 %pythoncode %{
 

--- a/src/STAT_FrontEnd.C
+++ b/src/STAT_FrontEnd.C
@@ -47,9 +47,6 @@ extern int *gStatGraphRoutinesRanksList;
 //! the length of the ranks list
 extern int gStatGraphRoutinesRanksListLength;
 
-//! the LMON status bit vector to detect daemon and application exit
-static int gsLmonState = 0;
-
 //! frame label to indicate an error
 const char *gErrorLabel = "daemon error";
 
@@ -82,6 +79,14 @@ extern int gNumEdgeAttrs;
 
 STAT_FrontEnd::STAT_FrontEnd()
 {
+    char *pHangTime = getenv("STAT_FE_HANG_SECONDS");
+    if (pHangTime) {
+        int hangTime = atoi(pHangTime);
+        while (hangTime--) {
+            sleep(1);
+        }
+    }
+ 
     int intRet;
     char tmp[BUFSIZE], *envValue;
     struct timeval timeStamp;
@@ -103,28 +108,11 @@ STAT_FrontEnd::STAT_FrontEnd()
         setenv("MRNET_DEBUG_LOG_DIRECTORY", envValue, 1);
 
     /* Set MRNet and LMON rsh command */
-    envValue = getenv("STAT_LMON_REMOTE_LOGIN");
-    if (envValue != NULL)
-        setenv("LMON_REMOTE_LOGIN", envValue, 1);
     envValue = getenv("STAT_XPLAT_RSH");
     if (envValue != NULL)
         setenv("XPLAT_RSH", envValue, 1);
 
-    /* Set LMON_DEBUG_BES */
-    envValue = getenv("STAT_LMON_DEBUG_BES");
-    if (envValue != NULL)
-        setenv("LMON_DEBUG_BES", envValue, 1);
-
     /* Set the launchmon and mrnet_commnode paths based on STAT env vars */
-    envValue = getenv("STAT_LMON_PREFIX");
-    if (envValue != NULL)
-        setenv("LMON_PREFIX", envValue, 1);
-    envValue = getenv("STAT_LMON_LAUNCHMON_ENGINE_PATH");
-    if (envValue != NULL)
-        setenv("LMON_LAUNCHMON_ENGINE_PATH", envValue, 1);
-    envValue = getenv("STAT_LMON_NEWLAUNCHMON_ENGINE_PATH");
-    if (envValue != NULL)
-        setenv("LMON_NEWLAUNCHMON_ENGINE_PATH", envValue, 1);
     envValue = getenv("STAT_MRNET_COMM_PATH");
     if (envValue != NULL)
     {
@@ -227,21 +215,14 @@ STAT_FrontEnd::STAT_FrontEnd()
     statInitializeMergeFunctions();
 
     /* Get the FE hostname */
-    string temp;
-    intRet = XPlat::NetUtils::GetLocalHostName(temp);
-    if (intRet == 0)
-        snprintf(hostname_, BUFSIZE, "%s", temp.c_str());
-    else
-    {
-        intRet = gethostname(hostname_, BUFSIZE);
-        if (intRet != 0)
-            printMsg(STAT_WARNING, __FILE__, __LINE__, "gethostname failed with error code %d\n", intRet);
+    intRet = gethostname(hostname_, BUFSIZE);
+    if (intRet != 0) {
+        printMsg(STAT_WARNING, __FILE__, __LINE__, "gethostname failed with error code %d\n", intRet);
     }
 
     /* Initialize variables */
     launcherPid_ = 0;
     nApplNodes_ = 0;
-    proctabSize_ = 0;
     nApplProcs_ = 0;
     nDaemonsPerNode_ = 1;
 #ifdef STAT_PROCS_PER_NODE
@@ -256,7 +237,6 @@ STAT_FrontEnd::STAT_FrontEnd()
     topologySize_ = 0;
     logging_ = 0;
     jobId_ = 0;
-    lmonSession_ = -1;
     launcherArgv_ = NULL;
     applExe_ = NULL;
     remoteNode_ = NULL;
@@ -275,7 +255,6 @@ STAT_FrontEnd::STAT_FrontEnd()
     checkNodeAccess_ = false;
     verbose_ = STAT_VERBOSE_STDOUT;
     applicationOption_ = STAT_ATTACH;
-    proctab_ = NULL;
     network_ = NULL;
     broadcastCommunicator_ = NULL;
     broadcastStream_ = NULL;
@@ -341,18 +320,6 @@ STAT_FrontEnd::~STAT_FrontEnd()
     {
         free(nodeListFile_);
         nodeListFile_ = NULL;
-    }
-    if (proctab_ != NULL)
-    {
-        for (i = 0; i < proctabSize_; i++)
-        {
-            if (proctab_[i].pd.executable_name != NULL)
-                free(proctab_[i].pd.executable_name);
-            if (proctab_[i].pd.host_name != NULL)
-                free(proctab_[i].pd.host_name);
-        }
-        free(proctab_);
-        proctab_ = NULL;
     }
     if (broadcastStream_ != NULL)
     {
@@ -484,287 +451,6 @@ StatError_t STAT_FrontEnd::launchAndSpawnDaemons(char *remoteNode, bool isStatBe
     return STAT_OK;
 }
 
-StatError_t STAT_FrontEnd::setupForSerialAttach()
-{
-#ifdef BGL
-    printMsg(STAT_WARNING, __FILE__, __LINE__, "Serial attach not supported on Bluegene systems\n");
-    return STAT_WARNING;
-#endif
-    printMsg(STAT_STDOUT, __FILE__, __LINE__, "Setting up environment for seral attach...\n");
-    gsLmonState = gsLmonState | 0x00000002;
-    nApplProcs_ = proctabSize_;
-
-    return launchDaemons();
-}
-
-StatError_t STAT_FrontEnd::launchDaemons()
-{
-    int i, daemonArgc = 1;
-    unsigned int proctabSize, j;
-    char **daemonArgv = NULL, tempString[BUFSIZE];
-    static bool iIsFirstRun = true;
-    string applName;
-    set<string> exeNames;
-    lmon_rc_e lmonRet;
-    lmon_rm_info_t rmInfo;
-    StatError_t statError;
-
-    /* Initialize performance timer */
-    addPerfData("MRNet Launch Time", -1.0);
-    gTotalgStartTime.setTime();
-    gStartTime.setTime();
-
-    /* Increase the max proc and max fd limits for MRNet threads */
-#if (defined(HAVE_GETRLIMIT) && defined(HAVE_SETRLIMIT))
-    statError = increaseSysLimits();
-    if (statError != STAT_OK)
-        printMsg(statError, __FILE__, __LINE__, "Failed to increase limits... attemting to run with current configuration\n");
-#endif
-
-#ifdef STAT_GDB_BE
-        if (applicationOption_ == STAT_GDB_ATTACH || applicationOption_ == STAT_SERIAL_GDB_ATTACH)
-        {
-            // On PPC64LE systems the FE environment is not passed to the daemons.
-            // We need to send PYTHONPATH for the GDB BE component.
-            // We also need to send the GDB path since this variable isn't propagated either.
-            const char *gdbCommand, *pythonPath;
-            pythonPath = getenv("PYTHONPATH");
-            if (pythonPath == NULL)
-                pythonPath = ":";
-            gdbCommand = getenv("STAT_GDB");
-            if (gdbCommand == NULL)
-                gdbCommand = "gdb";
-            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Using STAT GDB attach %s and PYTHONPATH %s\n", gdbCommand, pythonPath);
-            daemonArgc += 4;
-            daemonArgv = (char **)realloc(daemonArgv, daemonArgc * sizeof(char *));
-            if (daemonArgv == NULL)
-            {
-                printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s malloc failed to allocate for daemon argv\n", strerror(errno));
-                return STAT_ALLOCATE_ERROR;
-            }
-            daemonArgv[daemonArgc - 5] = strdup("-P");
-            daemonArgv[daemonArgc - 4] = strdup(pythonPath);
-            daemonArgv[daemonArgc - 3] = strdup("-G");
-            daemonArgv[daemonArgc - 2] = strdup(gdbCommand);
-            daemonArgv[daemonArgc - 1] = NULL;
-        }
-#endif
-
-
-    if (applicationOption_ != STAT_SERIAL_ATTACH && applicationOption_ != STAT_SERIAL_GDB_ATTACH)
-    {
-        if (iIsFirstRun == true)
-        {
-            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Initializing LaunchMON\n");
-            lmonRet = LMON_fe_init(LMON_VERSION);
-            if (lmonRet != LMON_OK)
-            {
-                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to initialize Launchmon\n");
-                return STAT_LMON_ERROR;
-            }
-        }
-        iIsFirstRun = false;
-
-        printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Creating LaunchMON session\n");
-        lmonRet = LMON_fe_createSession(&lmonSession_);
-        if (lmonRet != LMON_OK)
-        {
-            printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to create Launchmon session\n");
-            return STAT_LMON_ERROR;
-        }
-
-        printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Registering pack function with LaunchMON\n");
-        lmonRet = LMON_fe_regPackForFeToBe(lmonSession_, statPack);
-        if (lmonRet != LMON_OK)
-        {
-            printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to register pack function\n");
-            return STAT_LMON_ERROR;
-        }
-
-        gsLmonState = 0;
-        if (isStatBench_ == false)
-        {
-            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Registering status CB function with LaunchMON\n");
-            lmonRet = LMON_fe_regStatusCB(lmonSession_, lmonStatusCb);
-            if (lmonRet != LMON_OK)
-            {
-                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to register status CB function\n");
-                return STAT_LMON_ERROR;
-            }
-        }
-        else
-            gsLmonState = gsLmonState | 0x00000002;
-
-        if (toolDaemonExe_ == NULL)
-        {
-            printMsg(STAT_ARG_ERROR, __FILE__, __LINE__, "Tool daemon path not set\n");
-            return STAT_ARG_ERROR;
-        }
-        daemonArgc += 2;
-        daemonArgv = (char **)realloc(daemonArgv, daemonArgc * sizeof(char *));
-        if (daemonArgv == NULL)
-        {
-            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s malloc failed to allocate for daemon argv\n", strerror(errno));
-            return STAT_ALLOCATE_ERROR;
-        }
-        daemonArgv[daemonArgc - 3] = strdup("-d");
-        snprintf(tempString, BUFSIZE, "%d", nDaemonsPerNode_);
-        daemonArgv[daemonArgc - 2] = strdup(tempString);
-        daemonArgv[daemonArgc - 1] = NULL;
-
-        statError = addDaemonLogArgs(daemonArgc, daemonArgv);
-        if (statError != STAT_OK)
-        {
-            printMsg(statError, __FILE__, __LINE__, "Failed to add daemon logging args\n");
-            return statError;
-        }
-        for (i = 0; i < daemonArgc; i++)
-            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "daemonArgv[%d] = %s\n", i, daemonArgv[i]);
-
-        if (applicationOption_ == STAT_ATTACH || applicationOption_ == STAT_GDB_ATTACH)
-        {
-            if (launcherPid_ == 0)
-            {
-                printMsg(STAT_ARG_ERROR, __FILE__, __LINE__, "Launcher PID not set\n");
-                return STAT_ARG_ERROR;
-            }
-
-            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Attaching to job launcher and spawning daemons\n");
-            lmonRet = LMON_fe_attachAndSpawnDaemons(lmonSession_, remoteNode_, launcherPid_, toolDaemonExe_, daemonArgv, NULL, NULL);
-            if (lmonRet != LMON_OK)
-            {
-                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to attach to job launcher and spawn daemons\n");
-                return STAT_LMON_ERROR;
-            }
-        }
-        else
-        {
-            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Launching the application and spawning daemons\n");
-            i = 0;
-            while (1)
-            {
-                if (launcherArgv_[i] == NULL)
-                    break;
-                printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Launcher argv[%d] = %s\n", i, launcherArgv_[i]);
-                i++;
-            }
-            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "remote node = %s, daemon = %s\n", remoteNode_, toolDaemonExe_);
-            lmonRet = LMON_fe_launchAndSpawnDaemons(lmonSession_, remoteNode_, launcherArgv_[0], launcherArgv_, toolDaemonExe_, daemonArgv, NULL, NULL);
-            if (lmonRet != LMON_OK)
-            {
-                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to launch job and spawn daemons\n");
-                return STAT_LMON_ERROR;
-            }
-
-            lmonRet = LMON_fe_getRMInfo(lmonSession_, &rmInfo);
-            if (lmonRet != LMON_OK)
-            {
-                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to get resource manager info\n");
-                return STAT_LMON_ERROR;
-            }
-            launcherPid_ = rmInfo.rm_launcher_pid;
-        }
-
-        printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Gathering the process table\n");
-        lmonRet = LMON_fe_getProctableSize(lmonSession_, &proctabSize_);
-        if (lmonRet != LMON_OK)
-        {
-            printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to get Process Table Size\n");
-            return STAT_LMON_ERROR;
-        }
-        proctab_ = (MPIR_PROCDESC_EXT *)malloc(proctabSize_ * sizeof(MPIR_PROCDESC_EXT));
-        if (proctab_ == NULL)
-        {
-            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s: Failed to allocate memory for the process table\n", strerror(errno));
-            return STAT_ALLOCATE_ERROR;
-        }
-        lmonRet = LMON_fe_getProctable(lmonSession_, proctab_, &proctabSize, proctabSize_);
-        if (lmonRet != LMON_OK)
-        {
-            printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to get Process Table\n");
-            return STAT_LMON_ERROR;
-        }
-
-        /* Get the resource manager information from LaunchMON */
-        lmonRet = LMON_fe_getRMInfo(lmonSession_, &lmonRmInfo_);
-        if (lmonRet != LMON_OK)
-        {
-            printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to get RM Info\n");
-            return STAT_LMON_ERROR;
-        }
-    } /* if (applicationOption_ != STAT_SERIAL_ATTACH && applicationOption_ != STAT_SERIAL_GDB_ATTACH) */
-
-    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Gathering application information\n");
-
-    /* Iterate over all unique exe names and concatenate to app name */
-    for (j = 0; j < proctabSize_; j++)
-    {
-        if (exeNames.find(proctab_[j].pd.executable_name) != exeNames.end())
-            continue;
-        exeNames.insert(proctab_[j].pd.executable_name);
-        if (j > 0)
-            applName += "_";
-        applName += basename(proctab_[j].pd.executable_name);
-    }
-    applExe_ = strdup(applName.c_str());
-    if (applExe_ == NULL)
-    {
-        printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to set applExe_ with strdup()\n", strerror(errno));
-        return STAT_ALLOCATE_ERROR;
-    }
-    nApplProcs_ = proctabSize_;
-    isLaunched_ = true;
-    gEndTime.setTime();
-    addPerfData("\tLaunchmon Launch Time", (gEndTime - gStartTime).getDoubleTime());
-    printMsg(STAT_VERBOSITY, __FILE__, __LINE__, "\tTool daemons launched\n");
-
-    if (strcmp(outDir_, "NULL") == 0 || strcmp(filePrefix_, "NULL") == 0)
-    {
-        statError = createOutputDir();
-        if (statError != STAT_OK)
-        {
-            printMsg(statError, __FILE__, __LINE__, "Failed to create output directory\n");
-            return statError;
-        }
-    }
-
-    statError = dumpProctab();
-    if (statError != STAT_OK)
-    {
-        printMsg(statError, __FILE__, __LINE__, "Failed to dump process table to a file\n");
-        return statError;
-    }
-
-    /* Set the application node list based on the process table */
-    printMsg(STAT_VERBOSITY, __FILE__, __LINE__, "\tPopulating application node list\n");
-    gStartTime.setTime();
-    if (isStatBench_ == true)
-        statError = STATBench_setAppNodeList();
-    else
-        statError = setAppNodeList();
-    if (statError != STAT_OK)
-    {
-        printMsg(statError, __FILE__, __LINE__, "Failed to set app node list\n");
-        return statError;
-    }
-    gEndTime.setTime();
-    addPerfData("\tApp Node List Creation Time", (gEndTime - gStartTime).getDoubleTime());
-
-    if (daemonArgv != NULL)
-    {
-        for (i = 0; i < daemonArgc; i++)
-        {
-            if (daemonArgv[i] == NULL)
-                break;
-            free(daemonArgv[i]);
-        }
-        free(daemonArgv);
-    }
-
-    return STAT_OK;
-}
-
-
 void beConnectCb(Event *event, void *dummy)
 {
     if ((event->get_Class() == Event::TOPOLOGY_EVENT) && (event->get_Type() == TopologyEvent::TOPOL_ADD_BE))
@@ -776,15 +462,24 @@ void beConnectCb(Event *event, void *dummy)
 }
 
 
-void nodeRemovedCb(Event *event, void *statObject)
+void nodeRemovedCb(Event *event, void *statObjectPtr)
 {
+    STAT_FrontEnd* statObject = (STAT_FrontEnd*)statObjectPtr;
     StatError_t statError;
+
+
+    if (!statObject->isAttached())
+    {
+        // No need to generate warnings here if the node removal is just being
+        // reported after the notification for application detaching.
+        return;
+    }
 
     if ((event->get_Class() == Event::TOPOLOGY_EVENT) && (event->get_Type() == TopologyEvent::TOPOL_REMOVE_NODE))
     {
         pthread_mutex_lock(&gMrnetCallbackMutex);
 #ifndef DYSECTAPI
-        ((STAT_FrontEnd *)statObject)->printMsg(STAT_WARNING, __FILE__, __LINE__, "MRNet detected a tool process exit.  Recovering with available resources.\n");
+        statObject->printMsg(STAT_WARNING, __FILE__, __LINE__, "MRNet detected a tool process exit.  Recovering with available resources.\n");
 #endif
         statError = ((STAT_FrontEnd *)statObject)->setRanksList();
 
@@ -794,8 +489,8 @@ void nodeRemovedCb(Event *event, void *statObject)
         if (statError != STAT_OK)
 #endif
         {
-            ((STAT_FrontEnd *)statObject)->printMsg(statError, __FILE__, __LINE__, "An error occurred when trying to recover from node removal\n");
-            ((STAT_FrontEnd *)statObject)->setHasFatalError(true);
+            statObject->printMsg(statError, __FILE__, __LINE__, "An error occurred when trying to recover from node removal\n");
+            statObject->setHasFatalError(true);
         }
         pthread_mutex_unlock(&gMrnetCallbackMutex);
     }
@@ -822,7 +517,7 @@ StatError_t STAT_FrontEnd::launchMrnetTree(StatTopology_t topologyType, char *to
 {
     int daemonArgc = 1, statArgc, i;
     unsigned int j, currentArg;
-    char topologyFileName[BUFSIZE], **daemonArgv = NULL, temp[BUFSIZE];
+    char topologyFileName[BUFSIZE], **daemonArgv = NULL;
     bool boolRet;
     StatError_t statError;
 
@@ -880,44 +575,12 @@ StatError_t STAT_FrontEnd::launchMrnetTree(StatTopology_t topologyType, char *to
             daemonArgv[daemonArgc - 1] = NULL;
         }
 #endif
-
-        printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "\tSetting up daemon args for serial attach and MRNet launch\n");
-        statArgc = 1 + 2 * proctabSize_;
-        daemonArgc += statArgc;
-        daemonArgv = (char **)realloc(daemonArgv, daemonArgc * sizeof(char *));
-        if (daemonArgv == NULL)
+        statError = addDaemonSerialProcArgs(daemonArgc, daemonArgv);
+        if (statError != STAT_OK)
         {
-            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to allocate %d bytes for argv\n", strerror(errno), daemonArgc);
-            return STAT_ALLOCATE_ERROR;
+            printMsg(statError, __FILE__, __LINE__, "Failed to add daemon process args\n");              free(daemonArgv);
+            return statError;
         }
-        daemonArgv[daemonArgc - statArgc - 1] = strdup("-s");
-        if (daemonArgv[0] == NULL)
-        {
-            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to strdup argv[0]\n", strerror(errno));
-            free(daemonArgv);
-            return STAT_ALLOCATE_ERROR;
-        }
-        for (j = 0; j < proctabSize_; j++)
-        {
-            currentArg = daemonArgc - statArgc - 1 + 2 * j + 1;
-            daemonArgv[currentArg] = strdup("-p");
-            if (daemonArgv[currentArg] == NULL)
-            {
-                printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to strdup argv[%d]\n", strerror(errno), currentArg);
-                free(daemonArgv);
-                return STAT_ALLOCATE_ERROR;
-            }
-            snprintf(temp, BUFSIZE, "%s@%s:%d", proctab_[j].pd.executable_name, proctab_[j].pd.host_name, proctab_[j].pd.pid);
-            currentArg++;
-            daemonArgv[currentArg] = strdup(temp);
-            if (daemonArgv[currentArg] == NULL)
-            {
-                printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to strdup(%s) argv[%d]\n", strerror(errno), temp, currentArg);
-                free(daemonArgv);
-                return STAT_ALLOCATE_ERROR;
-            }
-        }
-        daemonArgv[daemonArgc - 1] = NULL;
 
         statError = addDaemonLogArgs(daemonArgc, daemonArgv);
         if (statError != STAT_OK)
@@ -961,19 +624,12 @@ StatError_t STAT_FrontEnd::launchMrnetTree(StatTopology_t topologyType, char *to
     } /* if (applicationOption_ == STAT_SERIAL_ATTACH || applicationOption_ == STAT_SERIAL_GDB_ATTACH) */
     else
     {
-        if (lmonRmInfo_.rm_supported_types[lmonRmInfo_.index_to_cur_instance] == RC_alps)
+        statError = createMRNetNetwork(topologyFileName);
+        if (statError != STAT_OK)
         {
-            map<string, string> attrs;
-            char apidString[BUFSIZE];
-
-            snprintf(apidString, BUFSIZE, "%d", launcherPid_);
-            attrs["CRAY_ALPS_APRUN_PID"] = apidString;
-            attrs["CRAY_ALPS_STAGE_FILES"] = filterPath_;
-
-            network_ = Network::CreateNetworkFE(topologyFileName, NULL, NULL, &attrs);
+            return statError;
         }
-        else
-            network_ = Network::CreateNetworkFE(topologyFileName, NULL, NULL);
+
 
     } /* else branch of if (applicationOption_ == STAT_SERIAL_ATTAC || applicationOption_ == STAT_SERIAL_GDB_ATTACHH) */
 
@@ -1024,6 +680,7 @@ StatError_t STAT_FrontEnd::launchMrnetTree(StatTopology_t topologyType, char *to
         return STAT_MRNET_ERROR;
     }
     topologySize_ = leafInfo_.networkTopology->get_NumNodes();
+
     if (applicationOption_ == STAT_SERIAL_ATTACH || applicationOption_ == STAT_SERIAL_GDB_ATTACH)
         topologySize_ -= nApplNodes_; /* We need topologySize_ to not include BEs */
 
@@ -1098,7 +755,7 @@ StatError_t STAT_FrontEnd::connectMrnetTree(bool blocking)
     if (blocking == false)
     {
         sConnectAttempt = sConnectAttempt + 1;
-        if (!WIFBESPAWNED(gsLmonState))
+        if (daemonsHaveExited())
         {
             printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
             return STAT_DAEMON_ERROR;
@@ -1116,7 +773,7 @@ StatError_t STAT_FrontEnd::connectMrnetTree(bool blocking)
     {
         for (sConnectAttempt = 0; sConnectAttempt < sConnectTimeout * 100; sConnectAttempt++)
         {
-            if (!WIFBESPAWNED(gsLmonState))
+            if (daemonsHaveExited())
             {
                 printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
                 return STAT_DAEMON_ERROR;
@@ -1344,9 +1001,7 @@ StatError_t STAT_FrontEnd::setupConnectedMrnetTree()
         printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "STATBench releasing the job launcher\n");
         if (isLaunched_ == true)
         {
-            lmon_rc_e lmonRet = LMON_fe_detach(lmonSession_);
-            if (lmonRet != LMON_OK)
-                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Launchmon failed to detach from launcher... this probably means that the helper daemons exited normally\n");
+            detachFromLauncher("failed to detach from launcher... this probably means that the helper daemons exited normally\n");
             isLaunched_ = false;
         }
     }
@@ -1635,39 +1290,6 @@ void STAT_FrontEnd::getVersion(int *version)
 }
 
 
-StatError_t STAT_FrontEnd::dumpProctab()
-{
-    unsigned int i;
-    FILE *file;
-    char fileName[BUFSIZE];
-
-    snprintf(fileName, BUFSIZE, "%s/%s.ptab", outDir_, filePrefix_);
-    file = fopen(fileName, "w");
-    if (file == NULL)
-    {
-        printMsg(STAT_FILE_ERROR, __FILE__, __LINE__, "%s: fopen failed to create ptab file %s\n", strerror(errno), fileName);
-        return STAT_FILE_ERROR;
-    }
-
-    /* Write the job launcher host and PID */
-    if (remoteNode_ != NULL)
-        fprintf(file, "%s:%d\n", remoteNode_, launcherPid_);
-    else
-        fprintf(file, "%s:%d\n", hostname_, launcherPid_);
-
-    /* Write out the MPI ranks */
-    if (verbose_ == STAT_VERBOSE_FULL || logging_ & STAT_LOG_FE)
-        printMsg(STAT_VERBOSITY, __FILE__, __LINE__, "Process Table:\n");
-    for (i = 0; i < nApplProcs_; i++)
-    {
-        fprintf(file, "%d %s:%d %s\n", proctab_[i].mpirank, proctab_[i].pd.host_name, proctab_[i].pd.pid, proctab_[i].pd.executable_name);
-        if (verbose_ == STAT_VERBOSE_FULL || logging_ & STAT_LOG_FE)
-            printMsg(STAT_VERBOSITY, __FILE__, __LINE__, "%s: %s, pid: %d, MPI rank: %d\n", proctab_[i].pd.host_name, proctab_[i].pd.executable_name, proctab_[i].pd.pid, proctab_[i].mpirank);
-    }
-
-    fclose(file);
-    return STAT_OK;
-}
 
 StatError_t STAT_FrontEnd::startLog(unsigned int logType, char *logOutDir, bool withPid)
 {
@@ -1747,7 +1369,7 @@ StatError_t STAT_FrontEnd::receiveAck(bool blocking)
         statError = waitForFileRequests(streamId, tag, packet, intRet, expectedStreams);
         if (statError == STAT_PENDING_ACK)
         {
-            if (!WIFBESPAWNED(gsLmonState))
+            if (daemonsHaveExited())
             {
                 printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
                 isPendingAck_ = false;
@@ -1770,7 +1392,7 @@ StatError_t STAT_FrontEnd::receiveAck(bool blocking)
 #endif
         if (intRet == 0)
         {
-            if (!WIFBESPAWNED(gsLmonState))
+            if (daemonsHaveExited())
             {
                 printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
                 isPendingAck_ = false;
@@ -1829,7 +1451,7 @@ StatError_t STAT_FrontEnd::setDaemonNodes()
     string prettyHost;
     int intRet;
 
-    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Generating daemon node list: ");
+    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Generating daemon node list: \n");
     leafInfo_.networkTopology->get_BackEndNodes(nodes);
     if (nodes.size() <= 0)
     {
@@ -1865,34 +1487,11 @@ StatError_t STAT_FrontEnd::setDaemonNodes()
     return STAT_OK;
 }
 
-StatError_t STAT_FrontEnd::setAppNodeList()
-{
-    unsigned int i;
-    char *currentNode;
-
-    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Generating application node list: ");
-    applicationNodeMultiSet_.clear();
-    for (i = 0; i < nApplProcs_; i++)
-    {
-        currentNode = proctab_[i].pd.host_name;
-        if (applicationNodeMultiSet_.find(currentNode) == applicationNodeMultiSet_.end())
-        {
-            applicationNodeMultiSet_.insert(currentNode);
-            printMsg(STAT_LOG_MESSAGE, __FILE__, -1, "%s, ", currentNode);
-        }
-    }
-    printMsg(STAT_LOG_MESSAGE, __FILE__, -1, "\n");
-    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Application node list created\n");
-    nApplNodes_ = applicationNodeMultiSet_.size();
-
-    return STAT_OK;
-}
-
 StatError_t STAT_FrontEnd::createDaemonRankMap()
 {
     unsigned int i, j, mrnetRank, rank;
     int k, l;
-    char *currentNode;
+    const char *currentNode;
     IntList_t *daemonRanks, *newDaemonRanks;
     map<string, vector<int> > tempMap;
     map<string, vector<int> >::iterator tempMapIter;
@@ -1908,8 +1507,8 @@ StatError_t STAT_FrontEnd::createDaemonRankMap()
     /* First, create a map containing all daemons, with the MPI ranks that each daemon debugs */
     for (i = 0; i < nApplProcs_; i++)
     {
-        currentNode = proctab_[i].pd.host_name;
-        tempMap[currentNode].push_back(proctab_[i].mpirank);
+        currentNode = getHostnameForProc(i);
+        tempMap[currentNode].push_back(getMpiRankForProc(i));
     }
 
     /* Next populate the hostToMrnetRankMap */
@@ -2019,7 +1618,6 @@ StatError_t STAT_FrontEnd::createDaemonRankMap()
     printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Daemon rank map created\n");
     return STAT_OK;
 }
-
 
 StatError_t STAT_FrontEnd::setCommNodeList(const char *nodeList, bool checkAccess = true)
 {
@@ -2257,7 +1855,9 @@ StatError_t STAT_FrontEnd::createTopology(char *topologyFileName, StatTopology_t
     string::size_type dashPos, lastPos;
     StatError_t statError;
 
-    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Creating MRNet topology file\n");
+    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__,
+             "Creating MRNet topology file for %d processes on %d nodes\n",
+             nApplProcs_, nApplNodes_);
 
     envValue = getenv("STAT_CHECK_NODE_ACCESS");
     if (envValue != NULL)
@@ -2595,7 +2195,7 @@ StatError_t STAT_FrontEnd::checkVersion()
         intRet = stream->recv(&tag, packet, false);
         if (intRet == 0)
         {
-            if (!WIFBESPAWNED(gsLmonState))
+            if (daemonsHaveExited())
             {
                 printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
                 return STAT_DAEMON_ERROR;
@@ -2639,15 +2239,6 @@ StatError_t STAT_FrontEnd::checkVersion()
     return STAT_OK;
 }
 
-bool checkAppExit()
-{
-    return WIFKILLED(gsLmonState);
-}
-
-bool checkDaemonExit()
-{
-    return !WIFBESPAWNED(gsLmonState);
-}
 
 void checkPendingActions(STAT_FrontEnd *statFE)
 {
@@ -2674,12 +2265,12 @@ StatError_t STAT_FrontEnd::attachApplication(bool blocking)
         printMsg(STAT_NOT_CONNECTED_ERROR, __FILE__, __LINE__, "STAT daemons have not been launched\n");
         return STAT_NOT_CONNECTED_ERROR;
     }
-    if (WIFKILLED(gsLmonState))
+    if (isKilled())
     {
         printMsg(STAT_APPLICATION_EXITED, __FILE__, __LINE__, "LMON detected the application has exited\n");
         return STAT_APPLICATION_EXITED;
     }
-    if (!WIFBESPAWNED(gsLmonState))
+    if (daemonsHaveExited())
     {
         printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
         return STAT_DAEMON_ERROR;
@@ -2721,7 +2312,6 @@ StatError_t STAT_FrontEnd::attachApplication(bool blocking)
     return STAT_OK;
 }
 
-
 StatError_t STAT_FrontEnd::postAttachApplication()
 {
     printMsg(STAT_STDOUT, __FILE__, __LINE__, "Attached!\n");
@@ -2753,12 +2343,12 @@ StatError_t STAT_FrontEnd::pause(bool blocking)
         printMsg(STAT_NOT_CONNECTED_ERROR, __FILE__, __LINE__, "STAT daemons have not been launched\n");
         return STAT_NOT_CONNECTED_ERROR;
     }
-    if (WIFKILLED(gsLmonState))
+    if (isKilled())
     {
         printMsg(STAT_APPLICATION_EXITED, __FILE__, __LINE__, "LMON detected the application has exited\n");
         return STAT_APPLICATION_EXITED;
     }
-    if (!WIFBESPAWNED(gsLmonState))
+    if (daemonsHaveExited())
     {
         printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
         return STAT_DAEMON_ERROR;
@@ -2829,12 +2419,12 @@ StatError_t STAT_FrontEnd::resume(bool blocking)
         printMsg(STAT_NOT_CONNECTED_ERROR, __FILE__, __LINE__, "STAT daemons have not been launched\n");
         return STAT_NOT_CONNECTED_ERROR;
     }
-    if (WIFKILLED(gsLmonState))
+    if (isKilled())
     {
         printMsg(STAT_APPLICATION_EXITED, __FILE__, __LINE__, "LMON detected the application has exited\n");
         return STAT_APPLICATION_EXITED;
     }
-    if (!WIFBESPAWNED(gsLmonState))
+    if (daemonsHaveExited())
     {
         printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
         return STAT_DAEMON_ERROR;
@@ -2904,12 +2494,12 @@ StatError_t STAT_FrontEnd::sampleStackTraces(unsigned int sampleType, unsigned i
         printMsg(STAT_NOT_CONNECTED_ERROR, __FILE__, __LINE__, "STAT daemons have not been launched\n");
         return STAT_NOT_CONNECTED_ERROR;
     }
-    if (WIFKILLED(gsLmonState))
+    if (isKilled())
     {
         printMsg(STAT_APPLICATION_EXITED, __FILE__, __LINE__, "LMON detected the application has exited\n");
         return STAT_APPLICATION_EXITED;
     }
-    if (!WIFBESPAWNED(gsLmonState))
+    if (daemonsHaveExited())
     {
         printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
         return STAT_DAEMON_ERROR;
@@ -3010,7 +2600,7 @@ StatError_t STAT_FrontEnd::gatherImpl(StatProt_t type, bool blocking)
         printMsg(STAT_NOT_CONNECTED_ERROR, __FILE__, __LINE__, "STAT daemons have not been launched\n");
         return STAT_NOT_CONNECTED_ERROR;
     }
-    if (!WIFBESPAWNED(gsLmonState))
+    if (daemonsHaveExited())
     {
         printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
         return STAT_DAEMON_ERROR;
@@ -3075,7 +2665,7 @@ StatError_t STAT_FrontEnd::receiveStackTraces(bool blocking)
         intRet = mergeStream_->recv(&tag, packet, false);
         if (intRet == 0)
         {
-            if (!WIFBESPAWNED(gsLmonState))
+            if (daemonsHaveExited())
             {
                 printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
                 return STAT_DAEMON_ERROR;
@@ -3130,6 +2720,8 @@ StatError_t STAT_FrontEnd::receiveStackTraces(bool blocking)
     gEndTime.setTime();
     addPerfData("\tMerge", (gEndTime - gStartTime).getDoubleTime());
 
+    int numProcs = getNumProcs();
+    
     if (sampleType & STAT_SAMPLE_COUNT_REP)
     {
         sortedStackTraces = stackTraces;
@@ -3140,7 +2732,7 @@ StatError_t STAT_FrontEnd::receiveStackTraces(bool blocking)
         /* Translate the graphs into rank ordered bit vector */
         /* First we need to set the bit vector length to the proctab size, just in case there are missing ranks */
         extern int gStatGraphRoutinesTotalWidth;
-        gStatGraphRoutinesTotalWidth = statBitVectorLength(proctabSize_);
+        gStatGraphRoutinesTotalWidth = statBitVectorLength(numProcs);
 
         printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Creating sorted graph\n");
         gStartTime.setTime();
@@ -3248,7 +2840,7 @@ StatError_t STAT_FrontEnd::receiveStackTraces(bool blocking)
         }
         else
         {
-            edge = initializeBitVectorEdge(proctabSize_);
+            edge = initializeBitVectorEdge(numProcs);
             if (edge == NULL)
             {
                 printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "Failed to initialize edge\n");
@@ -3431,12 +3023,12 @@ char *STAT_FrontEnd::getNodeInEdge(int nodeId)
         printMsg(STAT_NOT_CONNECTED_ERROR, __FILE__, __LINE__, "STAT daemons have not been launched\n");
         return NULL;
     }
-    if (WIFKILLED(gsLmonState))
+    if (isKilled())
     {
         printMsg(STAT_APPLICATION_EXITED, __FILE__, __LINE__, "LMON detected the application has exited\n");
         return NULL;
     }
-    if (!WIFBESPAWNED(gsLmonState))
+    if (daemonsHaveExited())
     {
         printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
         return NULL;
@@ -3446,7 +3038,7 @@ char *STAT_FrontEnd::getNodeInEdge(int nodeId)
 
     if (nodeId == statStringHash(gErrorLabel))
     {
-        orderedEdge = initializeBitVectorEdge(proctabSize_);
+        orderedEdge = initializeBitVectorEdge(getNumProcs());
         if (orderedEdge == NULL)
         {
             printMsg(STAT_GRAPHLIB_ERROR, __FILE__, __LINE__, "Failed to initialize edge\n");
@@ -3473,7 +3065,7 @@ char *STAT_FrontEnd::getNodeInEdge(int nodeId)
             intRet = mergeStream_->recv(&tag, packet, false);
             if (intRet == 0)
             {
-                if (!WIFBESPAWNED(gsLmonState))
+                if (daemonsHaveExited())
                 {
                     printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
                     return NULL;
@@ -3691,35 +3283,10 @@ StatError_t STAT_FrontEnd::dumpPerf()
     return STAT_OK;
 }
 
-
-void STAT_FrontEnd::shutDown()
+bool STAT_FrontEnd::isAttached()
 {
-    int killed, detached;
-    StatError_t statError;
-    lmon_rc_e lmonRet;
-
-    statError = dumpPerf();
-    if (statError != STAT_OK)
-        printMsg(statError, __FILE__, __LINE__, "Failed to dump performance results\n");
-
-    if (network_ != NULL && isConnected_ == true)
-        shutdownMrnetTree();
-
-    killed = WIFKILLED(gsLmonState);
-    detached = !WIFBESPAWNED(gsLmonState);
-    if (isLaunched_ == true && killed == 0 && detached == 0)
-    {
-        if (lmonSession_ != -1)
-        {
-            lmonRet = LMON_fe_detach(lmonSession_);
-            if (lmonRet != LMON_OK)
-                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Launchmon failed to detach from launcher... have the daemons exited?\n");
-        }
-    }
-    isLaunched_ = false;
-    gsLmonState = gsLmonState &(~0x00000002);
+    return isAttached_;
 }
-
 
 StatError_t STAT_FrontEnd::detachApplication(bool blocking)
 {
@@ -3743,14 +3310,14 @@ StatError_t STAT_FrontEnd::detachApplication(int *stopList, int stopListSize, bo
         printMsg(STAT_NOT_CONNECTED_ERROR, __FILE__, __LINE__, "STAT daemons have not been launched\n");
         return STAT_NOT_CONNECTED_ERROR;
     }
-    if (WIFKILLED(gsLmonState))
+    if (isKilled())
     {
 #ifndef DYSECTAPI
         printMsg(STAT_APPLICATION_EXITED, __FILE__, __LINE__, "LMON detected the application has exited\n");
         return STAT_APPLICATION_EXITED;
 #endif
     }
-    if (!WIFBESPAWNED(gsLmonState))
+    if (daemonsHaveExited())
     {
 #ifndef DYSECTAPI
         printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
@@ -3914,12 +3481,12 @@ StatError_t STAT_FrontEnd::terminateApplication(bool blocking)
         printMsg(STAT_NOT_CONNECTED_ERROR, __FILE__, __LINE__, "STAT daemons have not been launched\n");
         return STAT_NOT_CONNECTED_ERROR;
     }
-    if (WIFKILLED(gsLmonState))
+    if (isKilled())
     {
         printMsg(STAT_APPLICATION_EXITED, __FILE__, __LINE__, "LMON detected the application has exited\n");
         return STAT_APPLICATION_EXITED;
     }
-    if (!WIFBESPAWNED(gsLmonState))
+    if (daemonsHaveExited())
     {
         printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
         return STAT_DAEMON_ERROR;
@@ -4192,89 +3759,6 @@ StatError_t STAT_FrontEnd::addLauncherArgv(const char *launcherArg)
     return STAT_OK;
 }
 
-
-StatError_t STAT_FrontEnd::addSerialProcess(const char *pidString)
-{
-    unsigned int pid;
-    char *remoteNode = NULL;
-    string::size_type delimPos;
-    string remotePid = pidString, remoteHost;
-
-    proctabSize_++;
-    proctab_ = (MPIR_PROCDESC_EXT *)realloc(proctab_, proctabSize_ * sizeof(MPIR_PROCDESC_EXT));
-    if (proctab_ == NULL)
-    {
-        printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s: Failed to allocate memory for the process table\n", strerror(errno));
-        return STAT_ALLOCATE_ERROR;
-    }
-
-    delimPos = remotePid.find_first_of("@");
-    if (delimPos != string::npos)
-    {
-        proctab_[proctabSize_ - 1].pd.executable_name = strdup(remotePid.substr(0, delimPos).c_str());
-        if (proctab_[proctabSize_ - 1].pd.executable_name == NULL)
-        {
-            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to set executable_name from %s\n", strerror(errno), remotePid.substr(0, delimPos).c_str());
-            return STAT_ALLOCATE_ERROR;
-        }
-        remotePid = remotePid.substr(delimPos + 1, remotePid.length());
-    }
-    else
-    {
-        proctab_[proctabSize_ - 1].pd.executable_name = strdup("output");
-        if (proctab_[proctabSize_ - 1].pd.executable_name == NULL)
-        {
-            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to set executable_name\n", strerror(errno));
-            return STAT_ALLOCATE_ERROR;
-        }
-    }
-
-    delimPos = remotePid.find_first_of(":");
-    if (delimPos != string::npos)
-    {
-        remoteHost = remotePid.substr(0, delimPos);
-        remoteNode = strdup(remoteHost.c_str());
-        if (remoteNode == NULL)
-        {
-            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to strdup remote node from %s\n", strerror(errno), remotePid.c_str());
-            return STAT_ALLOCATE_ERROR;
-        }
-        pid = atoi((remotePid.substr(delimPos + 1, remotePid.length())).c_str());
-    }
-    else
-        pid = atoi(remotePid.c_str());
-
-    proctab_[proctabSize_ - 1].mpirank = proctabSize_ - 1;
-    if (remoteNode != NULL)
-    {
-        if (strcmp(remoteNode, "localhost") == 0 || strcmp(remoteNode, "") == 0)
-        {
-            proctab_[proctabSize_ - 1].pd.host_name = strdup(hostname_);
-            if (proctab_[proctabSize_ - 1].pd.host_name == NULL)
-            {
-                printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to strdup(%s) to host_name\n", strerror(errno), hostname_);
-                free(remoteNode);
-                return STAT_ALLOCATE_ERROR;
-            }
-        }
-        else
-            proctab_[proctabSize_ - 1].pd.host_name = strdup(remoteNode);
-        free(remoteNode);
-    }
-    else
-    {
-        proctab_[proctabSize_ - 1].pd.host_name = strdup(hostname_);
-        if (proctab_[proctabSize_ - 1].pd.host_name == NULL)
-        {
-            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to strdup(%s) to host_name\n", strerror(errno), hostname_);
-            return STAT_ALLOCATE_ERROR;
-        }
-    }
-    proctab_[proctabSize_ - 1].pd.pid = pid;
-    return STAT_OK;
-}
-
-
 const char **STAT_FrontEnd::getLauncherArgv()
 {
     return (const char **)launcherArgv_;
@@ -4422,9 +3906,10 @@ StatError_t STAT_FrontEnd::setRanksList()
         for (applicationNodeMultiSetIter = applicationNodeMultiSet_.begin(); applicationNodeMultiSetIter != applicationNodeMultiSet_.end(); applicationNodeMultiSetIter++)
             if (leafInfo_.daemons.find(*applicationNodeMultiSetIter) == leafInfo_.daemons.end() && daemonIpAddrs.find(*applicationNodeMultiSetIter) == daemonIpAddrs.end())
                 daemonSet.insert(*applicationNodeMultiSetIter);
-        for (i = 0; i < proctabSize_; i++)
-            if (daemonSet.find(proctab_[i].pd.host_name) != daemonSet.end())
-                missingRanks_.insert(proctab_[i].mpirank);
+        int numProcs = getNumProcs();
+        for (i = 0; i < numProcs; i++)
+            if (daemonSet.find(getHostnameForProc(i)) != daemonSet.end())
+                missingRanks_.insert(getMpiRankForProc(i));
         printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Missing ranks list generated with %d tasks\n", missingRanks_.size());
     }
 
@@ -4545,23 +4030,6 @@ StatError_t STAT_FrontEnd::freeRemapTree(RemapNode_t *node)
 }
 
 
-StatError_t STAT_FrontEnd::sendDaemonInfo()
-{
-    lmon_rc_e lmonRet;
-
-    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Sending MRNet connection info to daemons\n");
-
-    lmonRet = LMON_fe_sendUsrDataBe(lmonSession_, (void *)&leafInfo_);
-    if (lmonRet != LMON_OK)
-    {
-        printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to send data to BE\n");
-        return STAT_LMON_ERROR;
-    }
-    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "MRNet connection info successfully sent to daemons\n");
-
-    return STAT_OK;
-}
-
 int statPack(void *data, void *buf, int bufMax, int *bufLen)
 {
     int total = 0, len, port, rank, daemonCount, daemonRank;
@@ -4652,66 +4120,6 @@ int statPack(void *data, void *buf, int bufMax, int *bufLen)
     *bufLen = total;
     return 0;
 }
-
-
-int lmonStatusCb(int *status)
-{
-    gsLmonState = *status;
-    return 0;
-}
-
-
-bool STAT_FrontEnd::checkNodeAccess(char *node)
-{
-    /* MRNet CPs launched through alps */
-    if (lmonRmInfo_.rm_supported_types != NULL)
-    {
-        if (lmonRmInfo_.rm_supported_types[lmonRmInfo_.index_to_cur_instance] == RC_alps)
-            return true;
-    }
-    char command[BUFSIZE], testOutput[BUFSIZE], runScript[BUFSIZE], checkHost[BUFSIZE], *rsh = NULL, *envValue;
-    FILE *output, *temp;
-
-    /* TODO: this is generally not good... a quick check for clusters where each node has the same hostname prefix */
-    /* A first level filter, compare the first 3 letters */
-    gethostname(checkHost, BUFSIZE);
-    if (strncmp(node, checkHost, 3) != 0 && strcmp(node, "localhost") != 0)
-        return false;
-
-    envValue = getenv("XPLAT_RSH");
-    if (envValue != NULL)
-        rsh = strdup(envValue);
-    if (rsh == NULL)
-    {
-        rsh = strdup("rsh");
-        if (rsh == NULL)
-        {
-             printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s: failed to set rsh command\n", strerror(errno));
-            return false;
-        }
-    }
-
-    /* Use run_one_sec script if available to tolerate rsh slowness/hangs */
-    snprintf(runScript, BUFSIZE, "%s/bin/run_one_sec", getInstallPrefix());
-    temp = fopen(runScript, "r");
-    if (temp == NULL)
-        snprintf(command, BUFSIZE, "%s %s hostname 2>1", rsh, node);
-    else
-    {
-        snprintf(command, BUFSIZE, "%s %s %s hostname 2>1", runScript, rsh, node);
-        fclose(temp);
-    }
-    output = popen(command, "r");
-    free(rsh);
-    if (output == NULL)
-        return false;
-    fgets(testOutput, sizeof(testOutput), output);
-    pclose(output);
-    if (strcmp(testOutput, "") == 0)
-        return false;
-    return true;
-}
-
 
 StatError_t STAT_FrontEnd::addDaemonLogArgs(int &daemonArgc, char ** &daemonArgv)
 {
@@ -4878,29 +4286,11 @@ int STAT_FrontEnd::getNDaemonsPerNode()
  * STATBench Routines
 **********************/
 
-StatError_t STAT_FrontEnd::STATBench_setAppNodeList()
-{
-    unsigned int i;
-    char *currentNode;
-
-    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Generating application node list\n");
-
-    applicationNodeMultiSet_.clear();
-    for (i = 0; i < nApplProcs_; i++)
-    {
-        currentNode = proctab_[i].pd.host_name;
-        applicationNodeMultiSet_.insert(currentNode);
-    }
-    nApplNodes_ = nApplProcs_;
-
-    return STAT_OK;
-}
 
 StatError_t STAT_FrontEnd::statBenchCreateStackTraces(unsigned int maxDepth, unsigned int nTasks, unsigned int nTraces, unsigned int functionFanout, int nEqClasses, unsigned int sampleType)
 {
     int tag, intRet;
     unsigned int i, j;
-    char name[BUFSIZE];
     StatError_t statError;
     PacketPtr packet;
 
@@ -4910,39 +4300,12 @@ StatError_t STAT_FrontEnd::statBenchCreateStackTraces(unsigned int maxDepth, uns
     /* Rework the proc table to represent the STATBench emulated application */
     gStartTime.setTime();
 
-    for (i = 0; i < proctabSize_; i++)
+    statError = STATBench_resetProctab(nTasks);
+    if (statError != STAT_OK)
     {
-        if (proctab_[i].pd.executable_name != NULL)
-            free(proctab_[i].pd.executable_name);
-        if (proctab_[i].pd.host_name != NULL)
-            free(proctab_[i].pd.host_name);
+        return statError;
     }
-    free(proctab_);
-    proctab_ = NULL;
 
-    nApplProcs_ = nApplNodes_ * nTasks;
-    proctabSize_ = nApplProcs_;
-    proctab_ = (MPIR_PROCDESC_EXT *)malloc(nApplNodes_ * nTasks * sizeof(MPIR_PROCDESC_EXT));
-    if (proctab_ == NULL)
-    {
-        printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s: Failed to create proctable\n", strerror(errno));
-        return STAT_ALLOCATE_ERROR;
-    }
-    for (i = 0; i < nApplNodes_; i++)
-    {
-        snprintf(name, BUFSIZE, "a%d", i);
-        for (j = 0; j < nTasks; j++)
-        {
-            proctab_[i * nTasks + j].mpirank = i * nTasks + j;
-            proctab_[i * nTasks + j].pd.host_name = strdup(name);
-            if (proctab_[i * nTasks + j].pd.host_name == NULL)
-            {
-                printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s: Failed to strdup(%s) for proctab_[%d]\n", strerror(errno), name, i * nTasks + j);
-                return STAT_ALLOCATE_ERROR;
-            }
-            proctab_[i * nTasks + j].pd.executable_name = NULL;
-        }
-    }
     gEndTime.setTime();
     addPerfData("\tProctable Creation Time", (gEndTime - gStartTime).getDoubleTime());
 
@@ -4995,12 +4358,12 @@ StatError_t STAT_FrontEnd::statBenchCreateStackTraces(unsigned int maxDepth, uns
         intRet = broadcastStream_->recv(&tag, packet, false);
         if (intRet == 0)
         {
-            if (WIFKILLED(gsLmonState))
+            if (isKilled())
             {
                 printMsg(STAT_APPLICATION_EXITED, __FILE__, __LINE__, "LMON detected the application has exited\n");
                 return STAT_APPLICATION_EXITED;
             }
-            if (!WIFBESPAWNED(gsLmonState))
+            if (daemonsHaveExited())
             {
                 printMsg(STAT_DAEMON_ERROR, __FILE__, __LINE__, "LMON detected the daemons have exited\n");
                 return STAT_DAEMON_ERROR;

--- a/src/STAT_FrontEnd.C
+++ b/src/STAT_FrontEnd.C
@@ -79,14 +79,6 @@ extern int gNumEdgeAttrs;
 
 STAT_FrontEnd::STAT_FrontEnd()
 {
-    char *pHangTime = getenv("STAT_FE_HANG_SECONDS");
-    if (pHangTime) {
-        int hangTime = atoi(pHangTime);
-        while (hangTime--) {
-            sleep(1);
-        }
-    }
- 
     int intRet;
     char tmp[BUFSIZE], *envValue;
     struct timeval timeStamp;
@@ -215,9 +207,16 @@ STAT_FrontEnd::STAT_FrontEnd()
     statInitializeMergeFunctions();
 
     /* Get the FE hostname */
-    intRet = gethostname(hostname_, BUFSIZE);
-    if (intRet != 0) {
-        printMsg(STAT_WARNING, __FILE__, __LINE__, "gethostname failed with error code %d\n", intRet);
+    string temp;
+    intRet = XPlat::NetUtils::GetLocalHostName(temp);
+    if (intRet == 0)
+        snprintf(hostname_, BUFSIZE, "%s", temp.c_str());
+    else
+    {
+        intRet = gethostname(hostname_, BUFSIZE);
+        if (intRet != 0) {
+            printMsg(STAT_WARNING, __FILE__, __LINE__, "gethostname failed with error code %d\n", intRet);
+        }
     }
 
     /* Initialize variables */

--- a/src/STAT_lmonFrontEnd.C
+++ b/src/STAT_lmonFrontEnd.C
@@ -1,0 +1,742 @@
+#include "STAT_lmonFrontEnd.h"
+
+using namespace std;
+using namespace MRN;
+
+//! the LMON status bit vector to detect daemon and application exit
+static int gsLmonState = 0;
+
+// start timer for composite operations
+extern STAT_timer gTotalgStartTime;
+
+// start timer for individual operations
+extern STAT_timer gStartTime;
+
+// end timer for individual operations
+extern STAT_timer gEndTime;
+
+
+STAT_lmonFrontEnd::STAT_lmonFrontEnd()
+    : lmonSession_(-1), proctab_(nullptr), proctabSize_(0)
+{
+    char* envValue = getenv("STAT_LMON_REMOTE_LOGIN");
+    if (envValue != NULL)
+        setenv("LMON_REMOTE_LOGIN", envValue, 1);
+
+    /* Set LMON_DEBUG_BES */
+    envValue = getenv("STAT_LMON_DEBUG_BES");
+    if (envValue != NULL)
+        setenv("LMON_DEBUG_BES", envValue, 1);
+
+    /* Set the launchmon and mrnet_commnode paths based on STAT env vars */
+    envValue = getenv("STAT_LMON_PREFIX");
+    if (envValue != NULL)
+        setenv("LMON_PREFIX", envValue, 1);
+    envValue = getenv("STAT_LMON_LAUNCHMON_ENGINE_PATH");
+    if (envValue != NULL)
+        setenv("LMON_LAUNCHMON_ENGINE_PATH", envValue, 1);
+    envValue = getenv("STAT_LMON_NEWLAUNCHMON_ENGINE_PATH");
+    if (envValue != NULL)
+        setenv("LMON_NEWLAUNCHMON_ENGINE_PATH", envValue, 1);
+}
+
+STAT_lmonFrontEnd::~STAT_lmonFrontEnd()
+{
+    if (proctab_ != NULL)
+    {
+        for (int i = 0; i < proctabSize_; i++)
+        {
+            if (proctab_[i].pd.executable_name != NULL)
+                free(proctab_[i].pd.executable_name);
+            if (proctab_[i].pd.host_name != NULL)
+                free(proctab_[i].pd.host_name);
+        }
+        free(proctab_);
+        proctab_ = NULL;
+    }
+}
+
+StatError_t STAT_lmonFrontEnd::setupForSerialAttach()
+{
+#ifdef BGL
+    printMsg(STAT_WARNING, __FILE__, __LINE__, "Serial attach not supported on Bluegene systems\n");
+    return STAT_WARNING;
+#endif
+    printMsg(STAT_STDOUT, __FILE__, __LINE__, "Setting up environment for serial attach...\n");
+    gsLmonState = gsLmonState | 0x00000002;
+    nApplProcs_ = proctabSize_;
+
+    return launchDaemons();
+}
+
+StatError_t STAT_lmonFrontEnd::launchDaemons()
+{
+    int i, daemonArgc = 1;
+    unsigned int proctabSize, j;
+    char **daemonArgv = NULL, tempString[BUFSIZE];
+    static bool iIsFirstRun = true;
+    string applName;
+    set<string> exeNames;
+    lmon_rc_e lmonRet;
+    lmon_rm_info_t rmInfo;
+    StatError_t statError;
+
+    /* Initialize performance timer */
+    addPerfData("MRNet Launch Time", -1.0);
+    gTotalgStartTime.setTime();
+    gStartTime.setTime();
+
+    /* Increase the max proc and max fd limits for MRNet threads */
+#if (defined(HAVE_GETRLIMIT) && defined(HAVE_SETRLIMIT))
+    statError = increaseSysLimits();
+    if (statError != STAT_OK)
+        printMsg(statError, __FILE__, __LINE__, "Failed to increase limits... attemting to run with current configuration\n");
+#endif
+
+#ifdef STAT_GDB_BE
+        if (applicationOption_ == STAT_GDB_ATTACH || applicationOption_ == STAT_SERIAL_GDB_ATTACH)
+        {
+            // On PPC64LE systems the FE environment is not passed to the daemons.
+            // We need to send PYTHONPATH for the GDB BE component.
+            // We also need to send the GDB path since this variable isn't propagated either.
+            const char *gdbCommand, *pythonPath;
+            pythonPath = getenv("PYTHONPATH");
+            if (pythonPath == NULL)
+                pythonPath = ":";
+            gdbCommand = getenv("STAT_GDB");
+            if (gdbCommand == NULL)
+                gdbCommand = "gdb";
+            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Using STAT GDB attach %s and PYTHONPATH %s\n", gdbCommand, pythonPath);
+            daemonArgc += 4;
+            daemonArgv = (char **)realloc(daemonArgv, daemonArgc * sizeof(char *));
+            if (daemonArgv == NULL)
+            {
+                printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s malloc failed to allocate for daemon argv\n", strerror(errno));
+                return STAT_ALLOCATE_ERROR;
+            }
+            daemonArgv[daemonArgc - 5] = strdup("-P");
+            daemonArgv[daemonArgc - 4] = strdup(pythonPath);
+            daemonArgv[daemonArgc - 3] = strdup("-G");
+            daemonArgv[daemonArgc - 2] = strdup(gdbCommand);
+            daemonArgv[daemonArgc - 1] = NULL;
+        }
+#endif
+
+
+    if (applicationOption_ != STAT_SERIAL_ATTACH && applicationOption_ != STAT_SERIAL_GDB_ATTACH)
+    {
+        if (iIsFirstRun == true)
+        {
+            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Initializing LaunchMON\n");
+            lmonRet = LMON_fe_init(LMON_VERSION);
+            if (lmonRet != LMON_OK)
+            {
+                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to initialize Launchmon\n");
+                return STAT_LMON_ERROR;
+            }
+        }
+        iIsFirstRun = false;
+
+        printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Creating LaunchMON session\n");
+        lmonRet = LMON_fe_createSession(&lmonSession_);
+        if (lmonRet != LMON_OK)
+        {
+            printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to create Launchmon session\n");
+            return STAT_LMON_ERROR;
+        }
+
+        printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Registering pack function with LaunchMON\n");
+        lmonRet = LMON_fe_regPackForFeToBe(lmonSession_, statPack);
+        if (lmonRet != LMON_OK)
+        {
+            printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to register pack function\n");
+            return STAT_LMON_ERROR;
+        }
+
+        gsLmonState = 0;
+        if (isStatBench_ == false)
+        {
+            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Registering status CB function with LaunchMON\n");
+            lmonRet = LMON_fe_regStatusCB(lmonSession_, lmonStatusCb);
+            if (lmonRet != LMON_OK)
+            {
+                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to register status CB function\n");
+                return STAT_LMON_ERROR;
+            }
+        }
+        else
+            gsLmonState = gsLmonState | 0x00000002;
+
+        if (toolDaemonExe_ == NULL)
+        {
+            printMsg(STAT_ARG_ERROR, __FILE__, __LINE__, "Tool daemon path not set\n");
+            return STAT_ARG_ERROR;
+        }
+        daemonArgc += 2;
+        daemonArgv = (char **)realloc(daemonArgv, daemonArgc * sizeof(char *));
+        if (daemonArgv == NULL)
+        {
+            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s malloc failed to allocate for daemon argv\n", strerror(errno));
+            return STAT_ALLOCATE_ERROR;
+        }
+        daemonArgv[daemonArgc - 3] = strdup("-d");
+        snprintf(tempString, BUFSIZE, "%d", nDaemonsPerNode_);
+        daemonArgv[daemonArgc - 2] = strdup(tempString);
+        daemonArgv[daemonArgc - 1] = NULL;
+
+        statError = addDaemonLogArgs(daemonArgc, daemonArgv);
+        if (statError != STAT_OK)
+        {
+            printMsg(statError, __FILE__, __LINE__, "Failed to add daemon logging args\n");
+            return statError;
+        }
+        for (i = 0; i < daemonArgc; i++)
+            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "daemonArgv[%d] = %s\n", i, daemonArgv[i]);
+
+        if (applicationOption_ == STAT_ATTACH || applicationOption_ == STAT_GDB_ATTACH)
+        {
+            if (launcherPid_ == 0)
+            {
+                printMsg(STAT_ARG_ERROR, __FILE__, __LINE__, "Launcher PID not set\n");
+                return STAT_ARG_ERROR;
+            }
+
+            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Attaching to job launcher and spawning daemons\n");
+            lmonRet = LMON_fe_attachAndSpawnDaemons(lmonSession_, remoteNode_, launcherPid_, toolDaemonExe_, daemonArgv, NULL, NULL);
+            if (lmonRet != LMON_OK)
+            {
+                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to attach to job launcher and spawn daemons\n");
+                return STAT_LMON_ERROR;
+            }
+        }
+        else
+        {
+            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Launching the application and spawning daemons\n");
+            i = 0;
+            while (1)
+            {
+                if (launcherArgv_[i] == NULL)
+                    break;
+                printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Launcher argv[%d] = %s\n", i, launcherArgv_[i]);
+                i++;
+            }
+            printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "remote node = %s, daemon = %s\n", remoteNode_, toolDaemonExe_);
+            lmonRet = LMON_fe_launchAndSpawnDaemons(lmonSession_, remoteNode_, launcherArgv_[0], launcherArgv_, toolDaemonExe_, daemonArgv, NULL, NULL);
+            if (lmonRet != LMON_OK)
+            {
+                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to launch job and spawn daemons\n");
+                return STAT_LMON_ERROR;
+            }
+
+            lmonRet = LMON_fe_getRMInfo(lmonSession_, &rmInfo);
+            if (lmonRet != LMON_OK)
+            {
+                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to get resource manager info\n");
+                return STAT_LMON_ERROR;
+            }
+            launcherPid_ = rmInfo.rm_launcher_pid;
+        }
+
+        printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Gathering the process table\n");
+        lmonRet = LMON_fe_getProctableSize(lmonSession_, &proctabSize_);
+        if (lmonRet != LMON_OK)
+        {
+            printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to get Process Table Size\n");
+            return STAT_LMON_ERROR;
+        }
+        proctab_ = (MPIR_PROCDESC_EXT *)malloc(proctabSize_ * sizeof(MPIR_PROCDESC_EXT));
+        if (proctab_ == NULL)
+        {
+            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s: Failed to allocate memory for the process table\n", strerror(errno));
+            return STAT_ALLOCATE_ERROR;
+        }
+        lmonRet = LMON_fe_getProctable(lmonSession_, proctab_, &proctabSize, proctabSize_);
+        if (lmonRet != LMON_OK)
+        {
+            printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to get Process Table\n");
+            return STAT_LMON_ERROR;
+        }
+
+        /* Get the resource manager information from LaunchMON */
+        lmonRet = LMON_fe_getRMInfo(lmonSession_, &lmonRmInfo_);
+        if (lmonRet != LMON_OK)
+        {
+            printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to get RM Info\n");
+            return STAT_LMON_ERROR;
+        }
+    } /* if (applicationOption_ != STAT_SERIAL_ATTACH && applicationOption_ != STAT_SERIAL_GDB_ATTACH) */
+
+    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Gathering application information\n");
+
+    /* Iterate over all unique exe names and concatenate to app name */
+    for (j = 0; j < proctabSize_; j++)
+    {
+        if (exeNames.find(proctab_[j].pd.executable_name) != exeNames.end())
+            continue;
+        exeNames.insert(proctab_[j].pd.executable_name);
+        if (j > 0)
+            applName += "_";
+        applName += basename(proctab_[j].pd.executable_name);
+    }
+    applExe_ = strdup(applName.c_str());
+    if (applExe_ == NULL)
+    {
+        printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to set applExe_ with strdup()\n", strerror(errno));
+        return STAT_ALLOCATE_ERROR;
+    }
+    nApplProcs_ = proctabSize_;
+    isLaunched_ = true;
+    gEndTime.setTime();
+    addPerfData("\tLaunchmon Launch Time", (gEndTime - gStartTime).getDoubleTime());
+    printMsg(STAT_VERBOSITY, __FILE__, __LINE__, "\tTool daemons launched\n");
+
+    if (strcmp(outDir_, "NULL") == 0 || strcmp(filePrefix_, "NULL") == 0)
+    {
+        statError = createOutputDir();
+        if (statError != STAT_OK)
+        {
+            printMsg(statError, __FILE__, __LINE__, "Failed to create output directory\n");
+            return statError;
+        }
+    }
+
+    statError = dumpProctab();
+    if (statError != STAT_OK)
+    {
+        printMsg(statError, __FILE__, __LINE__, "Failed to dump process table to a file\n");
+        return statError;
+    }
+
+    /* Set the application node list based on the process table */
+    printMsg(STAT_VERBOSITY, __FILE__, __LINE__, "\tPopulating application node list\n");
+    gStartTime.setTime();
+    if (isStatBench_ == true)
+        statError = STATBench_setAppNodeList();
+    else
+        statError = setAppNodeList();
+    if (statError != STAT_OK)
+    {
+        printMsg(statError, __FILE__, __LINE__, "Failed to set app node list\n");
+        return statError;
+    }
+    gEndTime.setTime();
+    addPerfData("\tApp Node List Creation Time", (gEndTime - gStartTime).getDoubleTime());
+
+    if (daemonArgv != NULL)
+    {
+        for (i = 0; i < daemonArgc; i++)
+        {
+            if (daemonArgv[i] == NULL)
+                break;
+            free(daemonArgv[i]);
+        }
+        free(daemonArgv);
+    }
+
+    return STAT_OK;
+}
+
+StatError_t STAT_lmonFrontEnd::sendDaemonInfo()
+{
+    lmon_rc_e lmonRet;
+
+    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Sending MRNet connection info to daemons\n");
+
+    lmonRet = LMON_fe_sendUsrDataBe(lmonSession_, (void *)&leafInfo_);
+    if (lmonRet != LMON_OK)
+    {
+        printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Failed to send data to BE\n");
+        return STAT_LMON_ERROR;
+    }
+    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "MRNet connection info successfully sent to daemons\n");
+
+    return STAT_OK;
+}
+
+StatError_t STAT_lmonFrontEnd::addDaemonSerialProcArgs(int& daemonArgc, char ** &daemonArgv)
+{
+    char temp[BUFSIZE];
+    
+    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "\tSetting up daemon args for serial attach and MRNet launch\n");
+    int statArgc = 1 + 2 * proctabSize_;
+    daemonArgc += statArgc;
+    daemonArgv = (char **)realloc(daemonArgv, daemonArgc * sizeof(char *));
+    if (daemonArgv == NULL)
+    {
+        printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to allocate %d bytes for argv\n", strerror(errno), daemonArgc);
+        return STAT_ALLOCATE_ERROR;
+    }
+    daemonArgv[daemonArgc - statArgc - 1] = strdup("-s");
+    if (daemonArgv[0] == NULL)
+    {
+        printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to strdup argv[0]\n", strerror(errno));
+        free(daemonArgv);
+        return STAT_ALLOCATE_ERROR;
+    }
+    for (int j = 0; j < proctabSize_; j++)
+    {
+        int currentArg = daemonArgc - statArgc - 1 + 2 * j + 1;
+        daemonArgv[currentArg] = strdup("-p");
+        if (daemonArgv[currentArg] == NULL)
+        {
+            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to strdup argv[%d]\n", strerror(errno), currentArg);
+            free(daemonArgv);
+            return STAT_ALLOCATE_ERROR;
+        }
+        snprintf(temp, BUFSIZE, "%s@%s:%d", proctab_[j].pd.executable_name, proctab_[j].pd.host_name, proctab_[j].pd.pid);
+        currentArg++;
+        daemonArgv[currentArg] = strdup(temp);
+        if (daemonArgv[currentArg] == NULL)
+        {
+            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to strdup(%s) argv[%d]\n", strerror(errno), temp, currentArg);
+            free(daemonArgv);
+            return STAT_ALLOCATE_ERROR;
+        }
+    }
+
+    daemonArgv[daemonArgc - 1] = NULL;
+
+    return STAT_OK;
+}
+
+bool STAT_lmonFrontEnd::daemonsHaveExited()
+{
+    return !WIFBESPAWNED(gsLmonState);
+}
+
+bool STAT_lmonFrontEnd::isKilled()
+{
+    return WIFKILLED(gsLmonState);
+}
+
+void STAT_lmonFrontEnd::detachFromLauncher(const char* errMsg)
+{
+    lmon_rc_e lmonRet = LMON_fe_detach(lmonSession_);
+    if (lmonRet != LMON_OK)
+        printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, errMsg);
+}
+
+StatError_t STAT_lmonFrontEnd::dumpProctab()
+{
+    unsigned int i;
+    FILE *file;
+    char fileName[BUFSIZE];
+
+    snprintf(fileName, BUFSIZE, "%s/%s.ptab", outDir_, filePrefix_);
+    file = fopen(fileName, "w");
+    if (file == NULL)
+    {
+        printMsg(STAT_FILE_ERROR, __FILE__, __LINE__, "%s: fopen failed to create ptab file %s\n", strerror(errno), fileName);
+        return STAT_FILE_ERROR;
+    }
+
+    /* Write the job launcher host and PID */
+    if (remoteNode_ != NULL)
+        fprintf(file, "%s:%d\n", remoteNode_, launcherPid_);
+    else
+        fprintf(file, "%s:%d\n", hostname_, launcherPid_);
+
+    /* Write out the MPI ranks */
+    if (verbose_ == STAT_VERBOSE_FULL || logging_ & STAT_LOG_FE)
+        printMsg(STAT_VERBOSITY, __FILE__, __LINE__, "Process Table:\n");
+    for (i = 0; i < nApplProcs_; i++)
+    {
+        fprintf(file, "%d %s:%d %s\n", proctab_[i].mpirank, proctab_[i].pd.host_name, proctab_[i].pd.pid, proctab_[i].pd.executable_name);
+        if (verbose_ == STAT_VERBOSE_FULL || logging_ & STAT_LOG_FE)
+            printMsg(STAT_VERBOSITY, __FILE__, __LINE__, "%s: %s, pid: %d, MPI rank: %d\n", proctab_[i].pd.host_name, proctab_[i].pd.executable_name, proctab_[i].pd.pid, proctab_[i].mpirank);
+    }
+
+    fclose(file);
+    return STAT_OK;
+}
+
+StatError_t STAT_lmonFrontEnd::setAppNodeList()
+{
+    unsigned int i;
+    char *currentNode;
+
+    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Generating application node list: ");
+    applicationNodeMultiSet_.clear();
+    for (i = 0; i < nApplProcs_; i++)
+    {
+        currentNode = proctab_[i].pd.host_name;
+        if (applicationNodeMultiSet_.find(currentNode) == applicationNodeMultiSet_.end())
+        {
+            applicationNodeMultiSet_.insert(currentNode);
+            printMsg(STAT_LOG_MESSAGE, __FILE__, -1, "%s, ", currentNode);
+        }
+    }
+    printMsg(STAT_LOG_MESSAGE, __FILE__, -1, "\n");
+    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Application node list created\n");
+    nApplNodes_ = applicationNodeMultiSet_.size();
+
+    return STAT_OK;
+}
+
+StatError_t STAT_lmonFrontEnd::STATBench_setAppNodeList()
+{
+    unsigned int i;
+    char *currentNode;
+
+    printMsg(STAT_LOG_MESSAGE, __FILE__, __LINE__, "Generating application node list\n");
+
+    applicationNodeMultiSet_.clear();
+    for (i = 0; i < nApplProcs_; i++)
+    {
+        currentNode = proctab_[i].pd.host_name;
+        applicationNodeMultiSet_.insert(currentNode);
+    }
+    nApplNodes_ = nApplProcs_;
+
+    return STAT_OK;
+}
+
+StatError_t STAT_lmonFrontEnd::STATBench_resetProctab(unsigned int nTasks)
+{
+    char name[BUFSIZE];
+
+    for (int i = 0; i < proctabSize_; i++)
+    {
+        if (proctab_[i].pd.executable_name != NULL)
+            free(proctab_[i].pd.executable_name);
+        if (proctab_[i].pd.host_name != NULL)
+            free(proctab_[i].pd.host_name);
+    }
+    free(proctab_);
+    proctab_ = NULL;
+
+    nApplProcs_ = nApplNodes_ * nTasks;
+    proctabSize_ = nApplProcs_;
+    proctab_ = (MPIR_PROCDESC_EXT *)malloc(nApplNodes_ * nTasks * sizeof(MPIR_PROCDESC_EXT));
+    if (proctab_ == NULL)
+    {
+        printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s: Failed to create proctable\n", strerror(errno));
+        return STAT_ALLOCATE_ERROR;
+    }
+
+    for (int i = 0; i < nApplNodes_; i++)
+    {
+        snprintf(name, BUFSIZE, "a%d", i);
+        for (int j = 0; j < nTasks; j++)
+        {
+            proctab_[i * nTasks + j].mpirank = i * nTasks + j;
+            proctab_[i * nTasks + j].pd.host_name = strdup(name);
+            if (proctab_[i * nTasks + j].pd.host_name == NULL)
+            {
+                printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s: Failed to strdup(%s) for proctab_[%d]\n", strerror(errno), name, i * nTasks + j);
+                return STAT_ALLOCATE_ERROR;
+            }
+            proctab_[i * nTasks + j].pd.executable_name = NULL;
+        }
+    }
+
+    return STAT_OK;
+}
+
+
+
+bool checkAppExit()
+{
+    return WIFKILLED(gsLmonState);
+}
+
+bool checkDaemonExit()
+{
+    return !WIFBESPAWNED(gsLmonState);
+}
+
+int lmonStatusCb(int *status)
+{
+    gsLmonState = *status;
+    return 0;
+}
+
+StatError_t STAT_lmonFrontEnd::createMRNetNetwork(const char* topologyFileName)
+{
+    network_ = Network::CreateNetworkFE(topologyFileName, NULL, NULL);
+
+    return STAT_OK;
+}
+
+void STAT_lmonFrontEnd::shutDown()
+{
+    int killed, detached;
+    StatError_t statError;
+    lmon_rc_e lmonRet;
+
+    statError = dumpPerf();
+    if (statError != STAT_OK)
+        printMsg(statError, __FILE__, __LINE__, "Failed to dump performance results\n");
+
+    if (network_ != NULL && isConnected_ == true)
+        shutdownMrnetTree();
+
+    killed = WIFKILLED(gsLmonState);
+    detached = !WIFBESPAWNED(gsLmonState);
+    if (isLaunched_ == true && killed == 0 && detached == 0)
+    {
+        if (lmonSession_ != -1)
+        {
+            lmonRet = LMON_fe_detach(lmonSession_);
+            if (lmonRet != LMON_OK)
+                printMsg(STAT_LMON_ERROR, __FILE__, __LINE__, "Launchmon failed to detach from launcher... have the daemons exited?\n");
+        }
+    }
+    isLaunched_ = false;
+    gsLmonState = gsLmonState &(~0x00000002);
+}
+
+StatError_t STAT_lmonFrontEnd::addSerialProcess(const char *pidString)
+{
+    unsigned int pid;
+    char *remoteNode = NULL;
+    string::size_type delimPos;
+    string remotePid = pidString, remoteHost;
+
+    proctabSize_++;
+    proctab_ = (MPIR_PROCDESC_EXT *)realloc(proctab_, proctabSize_ * sizeof(MPIR_PROCDESC_EXT));
+    if (proctab_ == NULL)
+    {
+        printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s: Failed to allocate memory for the process table\n", strerror(errno));
+        return STAT_ALLOCATE_ERROR;
+    }
+
+    delimPos = remotePid.find_first_of("@");
+    if (delimPos != string::npos)
+    {
+        proctab_[proctabSize_ - 1].pd.executable_name = strdup(remotePid.substr(0, delimPos).c_str());
+        if (proctab_[proctabSize_ - 1].pd.executable_name == NULL)
+        {
+            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to set executable_name from %s\n", strerror(errno), remotePid.substr(0, delimPos).c_str());
+            return STAT_ALLOCATE_ERROR;
+        }
+        remotePid = remotePid.substr(delimPos + 1, remotePid.length());
+    }
+    else
+    {
+        proctab_[proctabSize_ - 1].pd.executable_name = strdup("output");
+        if (proctab_[proctabSize_ - 1].pd.executable_name == NULL)
+        {
+            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to set executable_name\n", strerror(errno));
+            return STAT_ALLOCATE_ERROR;
+        }
+    }
+
+    delimPos = remotePid.find_first_of(":");
+    if (delimPos != string::npos)
+    {
+        remoteHost = remotePid.substr(0, delimPos);
+        remoteNode = strdup(remoteHost.c_str());
+        if (remoteNode == NULL)
+        {
+            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to strdup remote node from %s\n", strerror(errno), remotePid.c_str());
+            return STAT_ALLOCATE_ERROR;
+        }
+        pid = atoi((remotePid.substr(delimPos + 1, remotePid.length())).c_str());
+    }
+    else
+        pid = atoi(remotePid.c_str());
+
+    proctab_[proctabSize_ - 1].mpirank = proctabSize_ - 1;
+    if (remoteNode != NULL)
+    {
+        if (strcmp(remoteNode, "localhost") == 0 || strcmp(remoteNode, "") == 0)
+        {
+            proctab_[proctabSize_ - 1].pd.host_name = strdup(hostname_);
+            if (proctab_[proctabSize_ - 1].pd.host_name == NULL)
+            {
+                printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to strdup(%s) to host_name\n", strerror(errno), hostname_);
+                free(remoteNode);
+                return STAT_ALLOCATE_ERROR;
+            }
+        }
+        else
+            proctab_[proctabSize_ - 1].pd.host_name = strdup(remoteNode);
+        free(remoteNode);
+    }
+    else
+    {
+        proctab_[proctabSize_ - 1].pd.host_name = strdup(hostname_);
+        if (proctab_[proctabSize_ - 1].pd.host_name == NULL)
+        {
+            printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s Failed to strdup(%s) to host_name\n", strerror(errno), hostname_);
+            return STAT_ALLOCATE_ERROR;
+        }
+    }
+    proctab_[proctabSize_ - 1].pd.pid = pid;
+    return STAT_OK;
+}
+
+bool STAT_lmonFrontEnd::checkNodeAccess(const char *node)
+{
+    /* MRNet CPs launched through alps */
+    if (lmonRmInfo_.rm_supported_types != NULL)
+    {
+        if (lmonRmInfo_.rm_supported_types[lmonRmInfo_.index_to_cur_instance] == RC_alps)
+            return true;
+    }
+    char command[BUFSIZE], testOutput[BUFSIZE], runScript[BUFSIZE], checkHost[BUFSIZE], *rsh = NULL, *envValue;
+    FILE *output, *temp;
+
+    /* TODO: this is generally not good... a quick check for clusters where each node has the same hostname prefix */
+    /* A first level filter, compare the first 3 letters */
+    gethostname(checkHost, BUFSIZE);
+    if (strncmp(node, checkHost, 3) != 0 && strcmp(node, "localhost") != 0)
+        return false;
+
+    envValue = getenv("XPLAT_RSH");
+    if (envValue != NULL)
+        rsh = strdup(envValue);
+    if (rsh == NULL)
+    {
+        rsh = strdup("rsh");
+        if (rsh == NULL)
+        {
+             printMsg(STAT_ALLOCATE_ERROR, __FILE__, __LINE__, "%s: failed to set rsh command\n", strerror(errno));
+            return false;
+        }
+    }
+
+    /* Use run_one_sec script if available to tolerate rsh slowness/hangs */
+    snprintf(runScript, BUFSIZE, "%s/bin/run_one_sec", getInstallPrefix());
+    temp = fopen(runScript, "r");
+    if (temp == NULL)
+        snprintf(command, BUFSIZE, "%s %s hostname 2>1", rsh, node);
+    else
+    {
+        snprintf(command, BUFSIZE, "%s %s %s hostname 2>1", runScript, rsh, node);
+        fclose(temp);
+    }
+    output = popen(command, "r");
+    free(rsh);
+    if (output == NULL)
+        return false;
+    fgets(testOutput, sizeof(testOutput), output);
+    pclose(output);
+    if (strcmp(testOutput, "") == 0)
+        return false;
+    return true;
+}
+
+
+int STAT_lmonFrontEnd::getNumProcs()
+{
+    return proctabSize_;
+}
+
+const char* STAT_lmonFrontEnd::getHostnameForProc(int procIdx)
+{
+    return proctab_[procIdx].pd.host_name;
+}
+int STAT_lmonFrontEnd::getMpiRankForProc(int procIdx)
+{
+    return proctab_[procIdx].mpirank;
+}
+
+#ifndef USE_CTI
+STAT_FrontEnd* STAT_FrontEnd::make()
+{
+    return new STAT_lmonFrontEnd();
+}
+#endif
+

--- a/src/STAT_lmonFrontEnd.h
+++ b/src/STAT_lmonFrontEnd.h
@@ -1,0 +1,72 @@
+#ifndef __STAT_LMONFRONTEND_H
+#define __STAT_LMONFRONTEND_H
+
+#include "STAT_FrontEnd.h"
+#include "lmon_api/lmon_fe.h"
+
+//! A callback function to detect daemon and application exit
+/*!
+    \param status - the input status vector
+    \return 0 on success, -1 on error
+
+    Determine if STAT is still connected to the resource manager
+    and if the application is still running.
+*/
+int lmonStatusCb(int *status);
+
+// Implementation of the STAT front end that uses launchmon to launch
+// the stat daemons
+class STAT_lmonFrontEnd : public STAT_FrontEnd
+{
+public:
+    STAT_lmonFrontEnd();
+
+    virtual ~STAT_lmonFrontEnd();
+
+    virtual StatError_t setupForSerialAttach();
+
+    virtual StatError_t launchDaemons();
+    virtual StatError_t sendDaemonInfo();
+    virtual void detachFromLauncher(const char* errMsg);
+    virtual void shutDown();
+
+    virtual StatError_t createMRNetNetwork(const char* topologyFileName);
+
+    virtual bool daemonsHaveExited();
+    virtual bool isKilled();
+
+    virtual int getNumProcs();
+    virtual const char* getHostnameForProc(int procIdx);
+    virtual int getMpiRankForProc(int procIdx);
+    virtual StatError_t dumpProctab();
+
+    virtual bool checkNodeAccess(const char *node);
+
+    virtual StatError_t addSerialProcess(const char *pidString);
+    virtual StatError_t addDaemonSerialProcArgs(int& deamonArgc, char ** &deamonArgv);
+
+    virtual StatError_t setAppNodeList();
+    virtual StatError_t STATBench_setAppNodeList();
+    virtual StatError_t STATBench_resetProctab(unsigned int nTasks);
+
+private:
+    //! validate the apid with CTI
+    /*!
+      return STAT_OK on success
+      Performs validate of apid/launcherPid_ with CTI
+    */
+    StatError_t validateApidWithCTI();
+
+    int lmonSession_;                                   /*!< the LaunchMON session ID */
+    lmon_rm_info_t lmonRmInfo_;                         /*!< the resource manager information from LMON */
+    MPIR_PROCDESC_EXT *proctab_;                        /*!< the process table */
+    unsigned int proctabSize_;                          /*!< the size of the process table */
+
+#ifdef CRAYXT
+        cti_app_id_t CTIAppId_;                             /*!< the CTI application ID */
+#endif
+};
+
+
+
+#endif


### PR DESCRIPTION
This is the first of 4 PR's to break #23 into manageable sized changes.    

Preparatory to providing a CTI implementation, this PR just isolates the launchmon dependencies into a derived class so I can provide a parallel CTI implementation that could be selected at build or run time.

The changes are - in most cases just moving blocks of code from STAT_FrontEnd.C to STAT_lmonFrontEnd.C, along with adding a few utility functions that can be implemented by the derived classes.

The next statement has been remedied:

> I apologize in advance because I am hampered by not being able to run this pure launchmon version directly.   We have been using a CTI/launchmon hybrid which was shoehorned into the code with a bunch of '#ifdef's.   I could test that version after the initial refactor, but have since removed the '#ifdef's.   So I could test a version very similar to this one, but this one directly.

