### PR TITLE
make basicConfig happy again

### DIFF
--- a/scripts/core_file_merger.py
+++ b/scripts/core_file_merger.py
@@ -583,7 +583,7 @@ def init_logging(input_loglevel, input_logfile):
         log_stream = None
         log_file = input_logfile
 
-    logging.basicConfig(level=input_loglevel, format=log_format, datefmt=log_date, filename=log_file, stream=log_stream, filemode='w')
+    logging.basicConfig(level=input_loglevel, format=log_format, datefmt=log_date, filemode='w')
     logging.getLogger().name = "MainThread"
     logging.log(logging.VERBOSE, "Processing started at %s" %(datetime.now()))
     return input_loglevel


### PR DESCRIPTION
for some reason I do not understand basicConfig kept giving me an error about
both 'filename' and 'stream' being provided.   So I took a big hammer and
removed both those parameters.