### PR TITLE
fix python library for 3.10+

### DIFF
--- a/config/x_ac_python.m4
+++ b/config/x_ac_python.m4
@@ -38,8 +38,9 @@ AC_DEFUN([X_AC_PYTHON], [
   AC_MSG_CHECKING([Python version])
   python_version=`$PYTHON -c "import distutils.sysconfig; \
     print(distutils.sysconfig.get_python_version());"`
+  python_minor_version=`echo $python_version | sed 's/.*\.\(.*\)/\1/'`
   if test $python_version '>' 2.99 ; then
-    if test $python_version '<' 3.8 ; then
+    if test $python_minor_version -lt 8 ; then
       m="m"
       python_version=$python_version$m
     else


### PR DESCRIPTION
use sed to filter out major version and compare minor versions directly.

For python versions >= 3.10, the direct string comparison against "3.8" fails to correctly identify the python library version. This PR modifies the python config script to compare just the minor version numbers.

I would be happy to hear suggestions to make this more readable as even simple sed scripts are a bit hard to parse. [There is a macro for version comparison in autoconf-archives](https://www.gnu.org/software/autoconf-archive/ax_compare_version.html) which we could use but I'm not that familiar with autoconf so I'm not sure what the best way is to include that.

I will also note here that distutils is deprecated and is removed in python 3.12, so the [`sysconfig`](https://docs.python.org/3.11/library/sysconfig.html) module (available from python 3.2) should be loaded directly in the future.