### PR TITLE
Use MI command for thread info in gdb-oneapi

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -37,7 +37,8 @@ Dependent Packages
    Python module can optionally be installed to allow the STAT GUI
    to perform syntax highlighting of source code. Another GUI
    requirement is the Graphviz package to render the DOT format
-   graph files.
+   graph files. The Python module "pygdbmi" is required for using
+   gdb-oneapi.
 
    STAT can also be optionally built with the Fast Global File
    Status (FGFS) library. This library helps STAT identify when a


### PR DESCRIPTION
The "info thread" command is replaced with "-thread-info" command. For this purpose, now gdb-oneapi script have a dependency on an open source python module "pygdbmi". This module provides the interface to parse the "-thread-info" MI Command response using its "gdbmiparser" function. The SIMD lane information is then extracted from it using the exectution_mask and simd_width info available for each thread. Also the test file oneapi_gdb_test.py is updated to test this change.