### PR TITLE
pick alphabetic first function name

### DIFF
--- a/config/x_ac_debuglibs.m4
+++ b/config/x_ac_debuglibs.m4
@@ -137,9 +137,9 @@ AC_DEFUN([X_AC_DEBUGLIBS], [
   )
   LDFLAGS=$TMP_LDFLAGS
   if test "$libstackwalk_found" = yes; then
-    BELIBS="-ldyninstAPI -lstackwalk -lpcontrol -lparseAPI -linstructionAPI -lsymtabAPI -lcommon -ldynElf -ldynDwarf -lsymLite $BELIBS"
+    BELIBS="-ldyninstAPI -lstackwalk -lpcontrol -lparseAPI -linstructionAPI -lsymtabAPI -lcommon -ldynElf -ldynDwarf -lsymLite -ltbb $BELIBS"
   else
-    LDFLAGS="$LDFLAGS -lstackwalk -lsymtabAPI -lpcontrol -lparseAPI -linstructionAPI -lcommon -lpthread"
+    LDFLAGS="$LDFLAGS -lstackwalk -lsymtabAPI -lpcontrol -lparseAPI -linstructionAPI -lcommon -ltbb -lpthread"
     AC_LINK_IFELSE([AC_LANG_PROGRAM(#include "walker.h"
       using namespace Dyninst;
       using namespace Dyninst::Stackwalker;
@@ -149,7 +149,7 @@ AC_DEFUN([X_AC_DEBUGLIBS], [
     )
     LDFLAGS=$TMP_LDFLAGS
     if test "$libstackwalk_found" = yes; then
-      BELIBS="-ldyninstAPI -lstackwalk -lsymtabAPI -lpcontrol -lparseAPI -linstructionAPI -lcommon $BELIBS"
+      BELIBS="-ldyninstAPI -lstackwalk -lsymtabAPI -lpcontrol -lparseAPI -linstructionAPI -lcommon -ltbb $BELIBS"
     else
       LDFLAGS="$LDFLAGS -lstackwalk -lsymtabAPI -lcommon -lpthread"
       AC_LINK_IFELSE([AC_LANG_PROGRAM(#include "walker.h"
@@ -161,7 +161,7 @@ AC_DEFUN([X_AC_DEBUGLIBS], [
       )
       LDFLAGS=$TMP_LDFLAGS
       if test "$libstackwalk_found" = yes; then
-        BELIBS="-ldyninstAPI -lstackwalk -lsymtabAPI -lcommon $BELIBS"
+        BELIBS="-ldyninstAPI -lstackwalk -lsymtabAPI -lcommon -ltbb $BELIBS"
       else
         AC_MSG_ERROR([libstackwalk is required.  Specify libstackwalk prefix with --with-stackwalker])
       fi

--- a/src/STAT_BackEnd.C
+++ b/src/STAT_BackEnd.C
@@ -2323,16 +2323,21 @@ std::string STAT_BackEnd::getFrameName(map<string, string> &nodeAttrs, const Fra
     bool boolRet;
     char buf[BUFSIZE], fileName[BUFSIZE], *pyFun = NULL, *pySource = NULL;
     string name;
+    vector<string> namesVector;
     Address addr;
     StatError_t statError;
 
     if (!(sampleType_ & STAT_SAMPLE_MODULE_OFFSET))
     {
-        boolRet = frame.getName(name);
-        if (boolRet == false)
-            name = "[unknown]";
-        else if (name == "")
-            name = "[empty]";
+        name = "[unknown]";
+        Function *func = getFunctionForFrame(frame);
+        if (func != NULL)
+        {
+            for (auto iter = func->pretty_names_begin(); iter != func->pretty_names_end(); ++iter)
+                namesVector.push_back(iter->c_str());
+            sort(namesVector.begin(), namesVector.end());
+            name = *(namesVector.begin());
+        }
         nodeAttrs["function"] = name;
     }
 


### PR DESCRIPTION
When DynInst returns multiple names for a frame select the one that is first alphabetically. Also at -ltbb to backend libraries.